### PR TITLE
fix & speedup show_gui

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scipy
 pymcubes
 trimesh
 dearpygui
+taichi


### PR DESCRIPTION
This pull request makes the following changes to the project:

1. Replaces dearpygui with taichi GUI, which is based on imgui and allows for direct transfer of tensors to the GPU frame buffer without requiring a trip back to the CPU.
2. Fixes a rotation bug where the rotation would not stop when the mouse movement stopped.
3. Adds visualization of dataset poses.

There are also the following interface changes:

1.  `w` and `s` can be used to move forward and backward instead of using the mouse scroll.
2.  `q` and `e` can be used to move up and down, and `a` and `d` can be used to move left and right.
3.  Use right-click instead of left-click to control rotation.