### PR TITLE
Fixing two issues in RayMarcher and VolumeRendering

### DIFF
--- a/models/csrc/setup.py
+++ b/models/csrc/setup.py
@@ -13,9 +13,9 @@ sources = glob.glob('*.cpp')+glob.glob('*.cu')
 
 setup(
     name='vren',
-    version='2.0',
-    author='kwea123',
-    author_email='kwea123@gmail.com',
+    version='2.0.1',
+    author='kwea123, jnhwkim',
+    author_email='kwea123@gmail.com, jnhwkim@gmail.com',
     description='cuda volume rendering library',
     long_description='cuda volume rendering library',
     ext_modules=[


### PR DESCRIPTION
This pull request addresses two issues that were identified in the RayMarcher and Volume Rendering code:

1. Random Order Aggregation in RayMarcher: Previously, the samples were aggregated in random order during the forward pass. To ensure correct calculations of `dL_drays_o` and `dL_drays_d` using `rays_a`, I have introduced a sorting mechanism to organize the aggregation process appropriately. Although this fix can be improved using CUDA implementation, it still performs well with reasonable speed.

2. Incorrect Gradient from Opacity: There was a problem with the gradient calculation from Opacity, which has now been rectified. The changes align the gradient calculation with the forward pass, ensuring accurate results. These fixes enhance the functionality and accuracy of the RayMarcher implementation.